### PR TITLE
Fixed README demo to read wav properly

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ See example notebook: [![Open In Colab](https://colab.research.google.com/assets
 import noisereduce as nr
 # load data
 rate, data = wavfile.read("mywav.wav")
+data /= 32768
 # select section of data that is noise
 noisy_part = data[10000:15000]
 # perform noise reduction


### PR DESCRIPTION
The current readme leaves out a crucial step in order for the algorithm to work correctly. This PR fixes that for future reference. 

I have tested with the fish example from Google Colab. It does not work as intended without this fix. 