### PR TITLE
fix typo in usage sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ import noisereduce as nr
 rate, data = wavfile.read("mywav.wav")
 # perform noise reduction
 reduced_noise = nr.reduce_noise(y=data, sr=rate)
-wavefile.write("mywav_reduced_noise.wav", rate, reduced_noise)
+wavfile.write("mywav_reduced_noise.wav", rate, reduced_noise)
 ```
 
 ### Arguments to `reduce_noise`


### PR DESCRIPTION
The simple example in the README does not work right away because it contains a small typo.