### PR TITLE
Update noisereduce.py - fixed tqdm disabling

### DIFF
--- a/noisereduce/noisereduce.py
+++ b/noisereduce/noisereduce.py
@@ -224,7 +224,7 @@ class SpectralGate:
                     
                     Parallel(n_jobs=self.n_jobs)(delayed(self._iterate_chunk)(filtered_chunk, pos, end0, start0, ich)
                        for pos, start0, end0, ich in zip(
-                        tqdm(pos_list, disable=self.use_tqdm), start_list, end_list, range(ich1, ich2 + 1)
+                        tqdm(pos_list, disable=not(self.use_tqdm)), start_list, end_list, range(ich1, ich2 + 1)
                     )
                    )
                     if self.flat:


### PR DESCRIPTION
I noticed that when the argument `use_tqdm` is set to `False`, progression bars appears. I made this small change and it seemed to behave correctly.
I think it is due to the fact that tqdm arguments asks the opposite (set disable to `True` then no progress bars are shown).   
I found this tricky to spot especially when other libraries or personal code use tqdm in parallel.