### PR TITLE
Add checking of device param in reduce_noise function

### DIFF
--- a/noisereduce/noisereduce.py
+++ b/noisereduce/noisereduce.py
@@ -124,7 +124,7 @@ def reduce_noise(
     if use_torch:
         # Available device types: https://pytorch.org/docs/stable/tensor_attributes.html#torch.device
         _device_regex = re.compile(r"^(cuda|cpu|mps)(:[0-9]+)?$")
-        device = device if _device_regex.fullmatch(device) is not None else None
+        device = device if _device_regex.fullmatch(device or "") is not None else None
         device = (
             torch.device(device or "cuda") if torch.cuda.is_available() else torch.device(device or "cpu")
         )

--- a/noisereduce/noisereduce.py
+++ b/noisereduce/noisereduce.py
@@ -8,6 +8,7 @@ try:
 except ImportError:
     TORCH_AVAILABLE = False
 if TORCH_AVAILABLE:
+    import re
     from noisereduce.spectralgate.streamed_torch_gate import StreamedTorchGate
 
 
@@ -121,8 +122,11 @@ def reduce_noise(
 
     # if using pytorch,
     if use_torch:
+        # Available device types: https://pytorch.org/docs/stable/tensor_attributes.html#torch.device
+        _device_regex = re.compile(r"^(cuda|cpu|mps)(:[0-9]+)?$")
+        device = device if _device_regex.fullmatch(device) is not None else None
         device = (
-            torch.device(device) if torch.cuda.is_available() else torch.device(device)
+            torch.device(device or "cuda") if torch.cuda.is_available() else torch.device(device or "cpu")
         )
         sg = StreamedTorchGate(
             y=y,


### PR DESCRIPTION
Added a regex checking on device parameter of the `reduce_noise` function, also make it use "cpu" or "cuda" if parameter is invalid based on cuda availability.

Improves previous code in regards of:

- Allowing the use of "cpu" if cuda is available.
- Avoid using an invalid device string.

Thanks!