### PR TITLE
Fixed a bug related to the device setting when using torch

### DIFF
--- a/noisereduce/noisereduce.py
+++ b/noisereduce/noisereduce.py
@@ -3,7 +3,6 @@ from noisereduce.spectralgate.nonstationary import SpectralGateNonStationary
 
 try:
     import torch
-
     TORCH_AVAILABLE = True
 except ImportError:
     TORCH_AVAILABLE = False
@@ -121,9 +120,6 @@ def reduce_noise(
 
     # if using pytorch,
     if use_torch:
-        device = (
-            torch.device(device) if torch.cuda.is_available() else torch.device(device)
-        )
         sg = StreamedTorchGate(
             y=y,
             sr=sr,

--- a/noisereduce/spectralgate/streamed_torch_gate.py
+++ b/noisereduce/spectralgate/streamed_torch_gate.py
@@ -50,7 +50,7 @@ class StreamedTorchGate(SpectralGate):
             n_jobs=n_jobs,
         )
 
-        self.device = device
+        self.device = torch.device(device if torch.cuda.is_available() else 'cpu')
 
         # noise convert to torch if needed
         if y_noise is not None:

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md", "r") as fh:
 setup(
     name="noisereduce",
     packages=find_packages(),
-    version="3.0.0",
+    version="3.0.1",
     description="Noise reduction using Spectral Gating in Python",
     author="Tim Sainburg",
     license="MIT",


### PR DESCRIPTION
Bugfix: https://github.com/timsainb/noisereduce/issues/94.

============================= test session starts =============================
collecting ... collected 6 items

test_reduction.py::test_reduce_generated_noise_stationary_with_noise_clip PASSED [ 16%]
test_reduction.py::test_reduce_generated_noise_stationary_without_noise_clip PASSED [ 33%]
test_reduction.py::test_reduce_generated_noise_nonstationary PASSED      [ 50%]
test_reduction.py::test_reduce_generated_noise_batches PASSED            [ 66%]
test_reduction.py::test_reduce_torch_cpu_stationary PASSED               [ 83%]
test_reduction.py::test_reduce_torch_cpu_non_stationary PASSED           [100%]