### PR TITLE
Fix misnamed torch flag in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ y : np.ndarray [shape=(# frames,) or (# channels, # frames)], real-valued
       If unspecified, defaults to ``win_length // 4`` (see below)., by default None
   n_jobs : int, optional
       Number of parallel jobs to run. Set at -1 to use all CPU cores, by default 1
-  torch_flag: bool, optional
+  use_torch: bool, optional
       Whether to use the torch version of spectral gating, by default False
   device: str, optional
       A device to run the torch spectral gating on, by default "cuda"


### PR DESCRIPTION
Hey just discovered the repo (very cool stuff btw), I tried playing around with different parameters and noticed the torch flag in the README is wrong.
Looking at the code, it should be `use_torch` instead of `torch_flag`

So i'm making this small PR to fix it :smile: 