### PR TITLE
Mps support

### DIFF
--- a/noisereduce/__init__.py
+++ b/noisereduce/__init__.py
@@ -1,1 +1,4 @@
+import os
+os.environ["PYTORCH_ENABLE_MPS_FALLBACK"] = "1"
+
 from noisereduce.noisereduce import reduce_noise

--- a/noisereduce/spectralgate/base.py
+++ b/noisereduce/spectralgate/base.py
@@ -137,7 +137,7 @@ class SpectralGate:
             i2b = self.n_frames
         else:
             i2b = i2
-        chunk = np.zeros((self.n_channels, i2 - i1))
+        chunk = np.zeros((self.n_channels, i2 - i1), dtype=self._dtype)
         chunk[:, i1b - i1: i2b - i1] = self.y[:, i1b:i2b]
         return chunk
 

--- a/noisereduce/spectralgate/streamed_torch_gate.py
+++ b/noisereduce/spectralgate/streamed_torch_gate.py
@@ -1,3 +1,4 @@
+import os
 import torch
 from noisereduce.spectralgate.base import SpectralGate
 from noisereduce.torchgate import TorchGate as TG
@@ -50,7 +51,10 @@ class StreamedTorchGate(SpectralGate):
             n_jobs=n_jobs,
         )
 
-        self.device = torch.device(device if torch.cuda.is_available() else 'cpu')
+        if "cuda" in device and not torch.cuda.is_available():
+            device = "cpu"
+
+        self.device = torch.device(device)
 
         # noise convert to torch if needed
         if y_noise is not None:


### PR DESCRIPTION
Added support for MPS graphics when using torchgate. Changes:
- Set PYTORCH_ENABLE_MPS_FALLBACK=1 when using MPS so that 'aten::unfold_backward' doesn't fail (see https://github.com/pytorch/pytorch/issues/77764)
- Set the dtype used in SpectralGate._read_chunk to the same datatype as the input data. This is needed since the chunks were always getting set to float64 which isn't supported on MPS. This way, any data type can be used.